### PR TITLE
use setup.py to build/install the package.

### DIFF
--- a/README
+++ b/README
@@ -37,19 +37,9 @@ If you want to plot your results quickly and easily, install the matplotlib pyth
 
 Building
 --------
-
-1. Edit the CAMB Makefile as normal.
-2. Run "make all" in the camb directory to build both the CAMB driver and libcamb.a
-3. Copy the file generatePyCamb.py into your main camb directory.
-4. Run "python generatePyCamb.py".  This will build a python file and a fortran file, and attempt to compile the fortran file using the f2py utility that comes with numpy.
-
-If you needed to link any extra libraries to build camb, edit this line at the bottom of generatePyCamb.py
-compile_command="f2py -c -m _pycamb -L. -lcamb -lgomp py_camb_wrap.f90 skip: makeparameters :"
-
-to include them after -lcamb.
-The gomp library listed in the current configuration is the OpenMP library for gfortran/gcc.  If you are not using it or them then you should remove it.
-
-The f2py command can be a bit flaky, especially when trying to use other compilers with it.  Read the documentation for it using "f2py --help" if it fails.
+python setup.py install --user
+or 
+python setup.py install --user
 
 Check if the installation has worked correctly using:
 > python
@@ -60,10 +50,6 @@ If no error messages are reported, pycamb built correctly.
 
 Using
 -----
-
-To use pycamb in a different directory to where it is built, add the camb directory to your python path.  In bash:
-cd /path/to/camb
-export PYTHONPATH=$PWD:$PYTHONPATH
 
 The functions currently available in the code are:
 pycamb.camb             #Get CMB power spectra; returns T,E,B,X

--- a/extract_camb.sh
+++ b/extract_camb.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+if [ "x$1" == x ]; then
+  echo trying do get CAMB.tar.gz from camb.info
+  cat<< EOF
+Licence
+You are licensed to use this software free of charge until January 2013 on condition that:
+    * Any publication using results of the code must be submitted to arXiv at the same time as, or before, submitting to a journal. arXiv must be updated with a version equivalent to that accepted by the journal on journal acceptance.
+    * If you identify any bugs you report them as soon as confirmed 
+
+  If you do not agree with the Licence, contact camb.info, and abort from here with Ctrl-C.
+  Otherwise, press <RETURN> to continue.
+EOF
+  read
+  wget http://camb.info/CAMB.tar.gz
+  FILE=CAMB.tar.gz
+else
+  FILE=$1
+fi
+
+if [ ! -f $FILE ]; then
+  echo $FILE is not a file.
+  exit 1
+fi
+
+tar -xzvf $FILE
+
+trap "rm -rf tmp" EXIT

--- a/generatePyCamb.py
+++ b/generatePyCamb.py
@@ -592,7 +592,7 @@ def makeFortranFooter():
     return "end module pycamb_mod"
     
 def main():
-    fortran_file=open("py_camb_wrap.f90","w")
+    fortran_file=open("src/py_camb_wrap.f90","w")
     fortran_file.write(makeFortranHeader())
     number_parameters = len(numericalParams) + len(logicalParameters)
     fortran_file.write(makeFortranClsCaller(number_parameters))
@@ -606,13 +606,9 @@ def main():
 #JZ This is where you would add calls to other routines that make more fortran code, for example to wrap other camb functions.
     fortran_file.close()
     
-    python_file=open("pycamb.py","w")
+    python_file=open("src/__init__.py","w")
     python_file.write(makePython(numericalParams,logicalParameters,defaultValues))
     python_file.close()
-    compile_command="f2py -c -m _pycamb -L. -lcamb -lgomp py_camb_wrap.f90 skip: makeparameters :"
-    print compile_command
-    system(compile_command)
 
-    
 if __name__=="__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,57 @@
+from numpy.distutils.core import setup, Extension
+from numpy import get_include
+from numpy import f2py
+import generatePyCamb
+import os.path
+
+# Get CAMB from http://camb.info, untar and copy *.[fF]90 to src/
+# this is done by the script extract_camb.sh
+
+cambsources = ['camb/%s' % f for f in [
+    'constants.f90',
+    'utils.F90',
+    'subroutines.f90',
+    'inifile.f90',
+    'power_tilt.f90',
+    'recfast.f90',
+    'reionization.f90',
+    'modules.f90',
+    'bessels.f90',
+    'equations.f90',
+    'halofit.f90',
+    'lensing.f90',
+    'SeparableBispectrum.F90',
+    'cmbmain.f90',
+    'camb.f90',
+]]
+
+for f in cambsources:
+  if not os.path.exists('camb/Makefile'):
+    raise Exception("At least one of CAMB code file: '%s' is not found. Download and extract to camb/" % f)
+
+try: os.mkdir('src')
+except: pass
+generatePyCamb.main()
+f2py.run_main(['-m', '_pycamb', '-h', '--overwrite-signature', 'src/py_camb_wrap.pyf', 
+         'src/py_camb_wrap.f90', 'skip:', 'makeparameters', ':'])
+
+setup(name="pycamb", version="0.1",
+      author="Joe Zuntz",
+      author_email="jaz@astro.ox.ac.uk",
+      description="python binding of camb, you need sign agreement and obtain camb source code to build this. Thus we can not GPL this code.",
+      url="http://github.com/rainwoodman/#",
+      download_url="http://web.phys.cmu.edu/~yfeng1/#",
+      zip_safe=False,
+      install_requires=['numpy'],
+      requires=['numpy'],
+      package_dir = {'pycamb': 'src'},
+      packages = [ 'pycamb' ],
+      scripts = [],
+      ext_modules = [
+        Extension("pycamb._pycamb", 
+             ['src/py_camb_wrap.pyf'] + cambsources +['src/py_camb_wrap.f90'],
+             extra_compile_args=['-O3', '-Dintp=npy_intp'],
+             include_dirs=[get_include()],
+        )]
+    )
+


### PR DESCRIPTION
NOTE: the built sources are not properly put into build/src.xxxxx.xxx,
but this is probably not an issue.

get CAMB code with
./extract_camb.sh

README updated as well, but extract_camb.sh is unmentioned as the script
won't register the user to camb.info database.
