### PR TITLE
a few quite big fixes.

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@ Building
 --------
 python setup.py install --user
 or 
-python setup.py install --user
+python setup.py install --inplace
 
 Check if the installation has worked correctly using:
 > python

--- a/generatePyCamb.py
+++ b/generatePyCamb.py
@@ -11,8 +11,7 @@ numericalParams=['omegab', 'omegac', 'omegav', 'omegan','H0','TCMB',
                 'Scalar_initial_condition','scalar_index','scalar_amp',
                 'scalar_running','tensor_index','tensor_ratio',
                '@lAccuracyBoost','@lSampleBoost','@w_lam','@cs2_lam',
-             '@AccuracyBoost'             ,
-
+             '@AccuracyBoost'             , 
 ]
 
 
@@ -398,6 +397,17 @@ endif
     
     return code
 
+def makeCLTemplatePath():
+  return """
+    subroutine setCLTemplatePath(path)
+        use camb
+        implicit none
+        character(LEN=1024), intent(in) :: path
+        highL_unlensed_cl_template = path
+    end subroutine setCLTemplatePath
+
+   """
+
 import pprint
 #Generate the python code that will wrap the fortran.
 def makePython(numericalParameters,logicalParameters,defaultValues):
@@ -419,6 +429,12 @@ _getpower = _pycamb.pycamb_mod.getpower
 _freepower = _pycamb.pycamb_mod.freepower
 _angulardiameter = _pycamb.pycamb_mod.angulardiameter
 _angulardiametervector = _pycamb.pycamb_mod.angulardiametervector
+import os.path
+_pycamb.pycamb_mod.setcltemplatepath(
+     os.path.join(
+        os.path.dirname(__file__),
+        'camb/HighLExtrapTemplate_lenspotentialCls.dat')
+)
 
 numericalParameters=%s
 logicalParameters=%s
@@ -602,6 +618,8 @@ def main():
     fortran_file.write(makeFortranMatterPowerCaller(number_parameters))
     fortran_file.write(makeFortranExtraFunctions(number_parameters))
     fortran_file.write(makeFortranParamSetter(numericalParams,logicalParameters,defaultValues))
+    fortran_file.write(makeCLTemplatePath())
+
     fortran_file.write(makeFortranFooter())
 #JZ This is where you would add calls to other routines that make more fortran code, for example to wrap other camb functions.
     fortran_file.close()

--- a/nonstopf2py.py
+++ b/nonstopf2py.py
@@ -1,0 +1,91 @@
+"""
+   An non-stop f2py. When the fortran program calls stop, it is trapped with a long jmp,
+   and the error is converted to a python error. 
+
+   A lot of inspiration came from patch_f2py.py in James Kermode's quippy 
+     (http://www.jrkermode.co.uk/quippy)
+   
+   currently supported fortran runtimes are:
+    ifcore (intel)
+    gfortran (gnu)
+
+   For new runtimes, compile a small f90 that uses stop 
+
+   boo.f90:
+      program boo
+          stop "boo the dog stops here"
+      end program boo
+
+   and
+     
+     objdump -t a.o
+
+   to find the function to override.
+
+  -- Yu Feng <yfeng1@cmu.edu> @ McWilliam Center, Carnegie Mellon 2012
+
+"""
+
+from numpy import f2py
+
+# trap the fortran STOP methods.
+# luckily they are not builtin/inlined.
+# we do not need to free 'message'. it appears to be staticly allocated
+# by the compiler.
+
+f2py.rules.module_rules['modulebody'] = f2py.rules.module_rules['modulebody'].replace(
+      '#includes0#\n', 
+    r"""#includes0#
+        #include <setjmp.h>
+        static char * _error;
+        static jmp_buf _env;
+        void for_stop_core(char * message, int len) {
+          _error = strndup(message, len);
+          longjmp(_env, 1);
+        }
+        void _gfortran_stop_string(char * message, int len) {
+          _error = strndup(message, len);
+          longjmp(_env, 1);
+        }
+     """)
+
+# here we fight the leak as f2py will no longer always return.
+# the easiest way is to first construct the return tuple, 
+# then free them all
+f2py.rules.routine_rules['body'] = f2py.rules.routine_rules['body'].replace(
+"""\t\tif (f2py_success) {
+#pyobjfrom#
+/*end of pyobjfrom*/
+\t\tCFUNCSMESS(\"Building return value.\\n\");
+\t\tcapi_buildvalue = Py_BuildValue(\"#returnformat#\"#return#);
+/*closepyobjfrom*/
+#closepyobjfrom#
+\t\t} /*if (f2py_success) after callfortranroutine*/""",
+
+"""\t\t{
+#pyobjfrom#
+/*end of pyobjfrom*/
+\t\tCFUNCSMESS(\"Building return value.\\n\");
+\t\tcapi_buildvalue = Py_BuildValue(\"#returnformat#\"#return#);
+/*closepyobjfrom*/
+#closepyobjfrom#
+\t\tif(!f2py_success) {
+\t\t\tPy_XDECREF(capi_buildvalue);
+\t\t\tcapi_buildvalue = NULL;
+\t\t}
+\t\t}
+/*if (f2py_success) after callfortranroutine*/
+"""
+)
+
+# the actual function call. free _error as PyErr_SetString will copy it.
+f2py.rules.routine_rules['body'] = f2py.rules.routine_rules['body'].replace(
+   '#callfortranroutine#\n', 
+   r"""
+       if(setjmp(_env)) {
+         PyErr_SetString(PyExc_RuntimeError, _error);
+         free(_error);
+       } else { 
+         #callfortranroutine# 
+       }
+   """)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from numpy.distutils.core import setup, Extension
 from numpy import get_include
-from numpy import f2py
 import generatePyCamb
 import os.path
+from nonstopf2py import f2py
 
 # Get CAMB from http://camb.info, untar and copy *.[fF]90 to src/
 # this is done by the script extract_camb.sh
@@ -32,6 +32,7 @@ for f in cambsources:
 try: os.mkdir('src')
 except: pass
 generatePyCamb.main()
+
 f2py.run_main(['-m', '_pycamb', '-h', '--overwrite-signature', 'src/py_camb_wrap.pyf', 
          'src/py_camb_wrap.f90', 'skip:', 'makeparameters', ':'])
 
@@ -44,13 +45,15 @@ setup(name="pycamb", version="0.1",
       zip_safe=False,
       install_requires=['numpy'],
       requires=['numpy'],
-      package_dir = {'pycamb': 'src'},
       packages = [ 'pycamb' ],
+      package_dir = {'pycamb': 'src'},
+      data_files = [('pycamb/camb', ['camb/HighLExtrapTemplate_lenspotentialCls.dat'])],
       scripts = [],
       ext_modules = [
         Extension("pycamb._pycamb", 
              ['src/py_camb_wrap.pyf'] + cambsources +['src/py_camb_wrap.f90'],
-             extra_compile_args=['-O3', '-Dintp=npy_intp'],
+             extra_compile_args=['-O0', '-g', '-Dintp=npy_intp'],
+#             libraries = {'noexit': ['src/noexit.c']},
              include_dirs=[get_include()],
         )]
     )


### PR DESCRIPTION
1 trap fortran stops on major compilers.
   so ipython won't crash when you do pycamb.camb(10). ifort and gfortran shall be both traped.

2 properly install / locate the template file
    for non lensed CL(what does it do anyways?)
    previously that file has to be in current directory. now you don't have to worry about it at all. It is copied to the package directory and the path is set in **init**.py . A new function is added to the generated f90 wrapper.
